### PR TITLE
add pseudocount 1/M/10 to p0 to avoid sequence with probability 0

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -67,7 +67,7 @@ We will assume we have a Multiple Sequence Alignment (MSA)in FASTA format. We ai
 2. Given a MSA, predict contacts
 3. Given a MSA, predict the mutational effect in all (ungapped) position of a given target sequence 
 
-## Load ArDCA package 
+## Load ArDCA package
 
 The following cell loads the package `ArDCA` (*Warning*: the first time it takes a while)
 
@@ -87,7 +87,9 @@ using ArDCA
 As a preliminary step, we learn the field and the coupling parameters $h,J$ from the MSA. To do so we use the `ardca` method that return the parameters (stored in `arnet` in the cell below), and the alignment in numerical format and other algorithms variables (stored in `arvar` in the cell below). The default autoregressive order is set to `:ENTROPIC`. We set the $L_2$ regularization to 0.02 for the $J$ and 0.001 for the $h$.
 
 The keyword arguments for the `ardca` method are (with their default value):
-
+* `lambdaJ::Real=0.01` coupling L₂ regularization parameter (lagrange multiplier)
+* `lambdaH::Real=0.01` field L₂ regularization parameter (lagrange multiplier)
+* `pc_factor::Real=0` pseudocount factor for calculation of `p0`
 * `epsconv::Real=1.0e-5` (convergence parameter)
 
 * `maxit::Int=1000` (maximum number of iteration - don't change)
@@ -97,7 +99,6 @@ The keyword arguments for the `ardca` method are (with their default value):
 * `method::Symbol=:LD_LBFGS` (optimization method)
 
 * `permorder::Union{Symbol,Vector{Ti}}=:ENTROPIC` (permutation order). Possible values are: `[:NATURAL, :ENTROPIC, :REV_ENTROPIC, :RANDOM]` or a custom permutation vector.
-
 
 ```
 arnet,arvar=ardca("data/PF14/PF00014_mgap6.fasta.gz", verbose=false, lambdaJ=0.02,lambdaH=0.001);

--- a/src/ar.jl
+++ b/src/ar.jl
@@ -9,7 +9,7 @@ Return two `struct`: `::ArNet` (containing the inferred hyperparameters) and `::
 Optional arguments:
 * `lambdaJ::Real=0.01` coupling L₂ regularization parameter (lagrange multiplier)
 * `lambdaH::Real=0.01` field L₂ regularization parameter (lagrange multiplier)
-* `pc_factor::Real=1/size(Z,2)` pseudocount factor for calculation of `p0`, defaults to one over the number of sequences.
+* `pc_factor::Real=0` pseudocount factor for calculation of `p0`, defaults to one over the number of sequences.
 * `epsconv::Real=1.0e-5` convergence value in minimzation
 * `maxit::Int=1000` maximum number of iteration in minimization
 * `verbose::Bool=true` set to `false` to stop printing convergence info on `stdout`
@@ -24,7 +24,7 @@ julia> arnet, arvar= ardca(Z,W,lambdaJ=0,lambdaH=0,permorder=:REV_ENTROPIC,epsco
 function ardca(Z::Array{Ti,2},W::Vector{Float64};
                 lambdaJ::Real=0.01,
                 lambdaH::Real=0.01,
-                pc_factor::Real=1/length(W),
+                pc_factor::Real=0,
                 epsconv::Real=1.0e-5,
                 maxit::Int=1000,
                 verbose::Bool=true,

--- a/src/ar.jl
+++ b/src/ar.jl
@@ -9,6 +9,7 @@ Return two `struct`: `::ArNet` (containing the inferred hyperparameters) and `::
 Optional arguments:
 * `lambdaJ::Real=0.01` coupling L₂ regularization parameter (lagrange multiplier)
 * `lambdaH::Real=0.01` field L₂ regularization parameter (lagrange multiplier)
+* `pc_factor::Real=1/size(Z,2)` pseudocount factor for calculation of `p0`, defaults to one over the number of sequences.
 * `epsconv::Real=1.0e-5` convergence value in minimzation
 * `maxit::Int=1000` maximum number of iteration in minimization
 * `verbose::Bool=true` set to `false` to stop printing convergence info on `stdout`
@@ -23,6 +24,7 @@ julia> arnet, arvar= ardca(Z,W,lambdaJ=0,lambdaH=0,permorder=:REV_ENTROPIC,epsco
 function ardca(Z::Array{Ti,2},W::Vector{Float64};
                 lambdaJ::Real=0.01,
                 lambdaH::Real=0.01,
+                pc_factor::Real=1/length(W),
                 epsconv::Real=1.0e-5,
                 maxit::Int=1000,
                 verbose::Bool=true,
@@ -38,7 +40,7 @@ function ardca(Z::Array{Ti,2},W::Vector{Float64};
     M = length(W)
     q = Int(maximum(Z_copy))
     aralg = ArAlg(method, verbose, epsconv, maxit)
-    arvar = ArVar(N, M, q, lambdaJ, lambdaH, Z_copy, W, permorder)
+    arvar = ArVar(N, M, q, lambdaJ, lambdaH, Z_copy, W, pc_factor, permorder)
     θ,psval = minimize_arnet(aralg, arvar)
     Base.GC.gc() # something wrong with SharedArrays on Mac
     ArNet(θ,arvar),arvar
@@ -55,6 +57,7 @@ Optional arguments:
 * `theta=:auto` if `:auto` compute reweighint automatically. Otherwise set a `Float64` value `0 ≤ theta ≤ 1`
 * `lambdaJ::Real=0.01` coupling L₂ regularization parameter (lagrange multiplier)
 * `lambdaH::Real=0.01` field L₂ regularization parameter (lagrange multiplier)
+* `pc_factor::Real=1/size(Z,2)` pseudocount factor for calculation of `p0`, defaults to one over the number of sequences.
 * `epsconv::Real=1.0e-5` convergence value in minimzation
 * `maxit::Int=1000` maximum number of iteration in minimization
 * `verbose::Bool=true` set to `false` to stop printing convergence info on `stdout`

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,7 +7,7 @@
     lambdaH::Float64
     Z::Array{Ti,2}
     W::Array{Float64,1}
-    pc::Float64 = 1 / length(W) # Pseudocount factor for p0, defaults to 1/M
+    pc::Float64 = 0 # Pseudocount factor for p0, defaults to 1/M
     IdxZ::Array{Int,2} # partial index computation to speed up energy calculation
     idxperm::Array{Int,1}
     

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-@kwdef struct ArVar{Ti <: Integer}
+Base.@kwdef struct ArVar{Ti <: Integer}
     N::Int
     M::Int
     q::Int

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-struct ArVar{Ti <: Integer}
+@kwdef struct ArVar{Ti <: Integer}
     N::Int
     M::Int
     q::Int
@@ -7,10 +7,17 @@ struct ArVar{Ti <: Integer}
     lambdaH::Float64
     Z::Array{Ti,2}
     W::Array{Float64,1}
+    pc::Float64 = 1 / length(W) # Pseudocount factor for p0, defaults to 1/M
     IdxZ::Array{Int,2} # partial index computation to speed up energy calculation
     idxperm::Array{Int,1}
     
-    function ArVar(N, M, q, lambdaJ, lambdaH, Z::Array{Ti,2}, W::Array{Float64,1}, permorder::Union{Symbol,Vector{Int}}) where Ti <: Integer
+    function ArVar(
+        N, M, q, lambdaJ, lambdaH, Z::Array{Ti,2}, W::Array{Float64,1}, pc, permorder::Union{Symbol,Vector{Int}}
+    ) where Ti <: Integer
+        if pc > 1 || pc < 0
+            error("Pseudocount factor `pc` must be between 0 and 1. Got $pc")
+        end
+
         idxperm = if typeof(permorder) == Symbol
             S = entropy(Z,W)
             if permorder === :ENTROPIC
@@ -38,7 +45,7 @@ struct ArVar{Ti <: Integer}
                 IdxZ[j,i] = (j - 1) * q2 + q * (Z[j,i] - 1)
             end
         end
-        new{Ti}(N, M, q, q^2, lambdaJ, lambdaH, Z, W, IdxZ,idxperm)
+        new{Ti}(N, M, q, q^2, lambdaJ, lambdaH, Z, W, pc, IdxZ,idxperm)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,11 +11,12 @@ end
 
 function computep0(var)
     @extract var:W Z q
+    pc = 1/size(Z, 2)
     p0 = zeros(q)
     for i in eachindex(W)
         p0[Z[1, i]] += W[i]
     end
-    return p0
+    return p0 * (1-pc) .+ pc/q
 end
 
 function compute_empirical_freqs(Z::AbstractArray{Ti,2}, W::AbstractVector{Float64}, q::Ti) where {Ti<:Integer}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,8 +10,7 @@ function read_fasta(filename::AbstractString, max_gap_fraction::Real, theta::Any
 end
 
 function computep0(var)
-    @extract var:W Z q
-    pc = 1/size(Z, 2)/10
+    @extract var:W Z q pc
     p0 = zeros(q)
     for i in eachindex(W)
         p0[Z[1, i]] += W[i]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@ end
 
 function computep0(var)
     @extract var:W Z q
-    pc = 1/size(Z, 2)
+    pc = 1/size(Z, 2)/10
     p0 = zeros(q)
     for i in eachindex(W)
         p0[Z[1, i]] += W[i]


### PR DESCRIPTION
Sometimes, I want to evaluate the ArDCA-likelihood of a sequence that has not been seen in training. Since `ArNet.p0` is not currently regularized, this can cause sequences to have a probability strictly 0. 
In some applications, this causes issues: for instance in ancestral sequence reconstruction, if a sequence at one leaf is assigned likelihood 0, every reconstruction above must have likelihood 0, causing algorithms to fail. 

This PR just adds a pseudocount `1/M/10`  to `p0`, where `M` is the number of sequences in the training alignment. Do you think it makes sense? 